### PR TITLE
use hydra 2.4.0-beta.2 and update program

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "sqlhydra.cli": {
-      "version": "2.4.0-beta.1",
+      "version": "2.4.0-beta.2",
       "commands": [
         "sqlhydra"
       ]

--- a/README.md
+++ b/README.md
@@ -8,19 +8,18 @@ Create the local database with:
 
 ```
 psql -d postgres -U [username] -f sql/create_db.sql
-``` 
+```
 
 Set an environment variable named "CONNSTRING_GAMES_LOCAL".
-
 
 ## TryHydra
 
 Project to try out (experimental release of) sqlhydra.
 
-We use SqlHydra to automatically generate a "database types" module `tryHydra/DbTypes.fs` (in the repo). Regenerate the hydra file by running: 
+We use SqlHydra to automatically generate a "database types" module `tryHydra/DbTypes.fs` (in the repo). Regenerate the hydra file by running:
 
 ```shell
-dotnet sqlhydra npgsql --project tryHydra/tryHydra.fsproj
+dotnet sqlhydra npgsql --project tryHydra/TryHydra.fsproj
 ```
 
 The first time you do this, you will be promted for some input parameters. These parameters are then saved in a file called `sqlhydra-npgsql.toml` so you don't have to give the input every time. If you want to change the params, such as which database is being used, you can edit the `.toml` file directly.

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -2,4 +2,4 @@ source https://api.nuget.org/v3/index.json
 
 storage: none
 nuget Npgsql
-nuget sqlhydra.query 2.4.0-beta.1 beta
+nuget sqlhydra.query 2.4.0-beta.2 beta

--- a/paket.lock
+++ b/paket.lock
@@ -22,7 +22,7 @@ NUGET
       System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: || (&& (>= net6.0) (< net7.0)) (&& (< net6.0) (>= netstandard2.1)) (&& (>= netstandard2.0) (< netstandard2.1))
       System.Text.Json (>= 8.0) - restriction: || (&& (>= net6.0) (< net7.0)) (&& (< net6.0) (>= netstandard2.1)) (&& (>= netstandard2.0) (< netstandard2.1))
       System.Threading.Channels (>= 8.0) - restriction: || (&& (< net6.0) (>= netstandard2.1)) (&& (>= netstandard2.0) (< netstandard2.1))
-    SqlHydra.Query (2.4.0-beta.1)
+    SqlHydra.Query (2.4.0-beta.2)
       FSharp.Core (>= 6.0.7) - restriction: || (&& (>= net6.0) (< net7.0)) (&& (< net6.0) (>= netstandard2.0))
       FSharp.Core (>= 7.0.200) - restriction: >= net7.0
       SqlKata (>= 2.4) - restriction: >= netstandard2.0

--- a/tryHydra/Database.fs
+++ b/tryHydra/Database.fs
@@ -21,8 +21,7 @@ let getInfo () =
 
         let! gamesInfo =
             selectAsync HydraReader.Read (Shared ctx) {
-                // want this to use the materialized view, table<games.games_with_info> instead
-                for row in table<games.games> do
+                for row in table<games.games_with_info> do
                     select row
             }
 

--- a/tryHydra/Program.fs
+++ b/tryHydra/Program.fs
@@ -1,4 +1,13 @@
 ﻿open Database
 
-printfn "Hello!"
-getInfo () |> Async.RunSynchronously |> Seq.tryHead |> printfn "Output: %A"
+let program () =
+    async {
+        let! gamesInfo = getInfo ()
+        printfn $"Found {Seq.length gamesInfo} entries in the games info materialized view."
+
+        match (Seq.tryHead gamesInfo) with
+        | Some game -> printfn $"The first game has info:\n {game}"
+        | None -> printfn "No game info found"
+    }
+
+program () |> Async.RunSynchronously


### PR DESCRIPTION
Sqlhydra 2.4.0-beta.2 is able to add an entry to the generated file for the materialized view, hooray! 

Slight bug(?): the generated file now ends up in `tryHydra/tryHydra/DbTypes.fs` rather than `tryHydra/DbTypes.fs`, and the same path change occurs in the added entry to the `.fsproj` file. Updating the "output" entry in the .toml file doesn't fix this issue. For this PR, I have manually moved the generated file to the right place, and fixed the .fsproj file.